### PR TITLE
Refactor CI

### DIFF
--- a/.github/workflows/build-and-check.yaml
+++ b/.github/workflows/build-and-check.yaml
@@ -1,0 +1,58 @@
+name: Build & check
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - assigned
+      - closed
+      - edited
+      - labeled
+      - locked
+      - ready_for_review
+      - review_request_removed
+      - review_requested
+      - unassigned
+      - unlabeled
+      - unlocked
+  workflow_dispatch:
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    outputs:
+      changes: ${{ steps.check-for-changes.outputs.diff }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+      - name: Get Yarn cache folder path
+        id: yarn-cache-folder
+        run: echo "::set-output name=path::$( yarn cache dir )"
+      - name: Set up Yarn cache
+        id: yarn-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-folder.outputs.path }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install Node packages via Yarn
+        run: yarn install --frozen-lockfile --cache-folder ${{ steps.yarn-cache-folder.outputs.path }}
+      - name: Build
+        run: yarn build
+      - name: Check for changes
+        id: check-for-changes
+        run: echo "::set-output name=diff::$( git diff )"
+  check:
+    name: Check distribution file
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - if: ${{ needs.build.outputs.changes != '' }}
+        name: Fail
+        run: exit 1

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,5 +1,7 @@
 name: Build & push
-on: pull_request
+on:
+  push:
+    branches-ignore: [ master ]
 jobs:
   build:
     name: Build & push
@@ -26,20 +28,21 @@ jobs:
         run: yarn install --frozen-lockfile --cache-folder ${{ steps.yarn-cache-folder.outputs.path }}
       - name: Build
         run: yarn build
-      - name: Configure Git
+      - name: Check for changes
+        id: check-for-changes
+        run: echo "::set-output name=diff::$( git diff )"
+      - if: ${{ steps.check-for-changes.outputs.diff != '' }}
+        name: Configure Git
         run: |
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git config user.name $GITHUB_ACTOR
-      - name: Stage distribution directory
+      - if: ${{ steps.check-for-changes.outputs.diff != '' }}
+        name: Stage distribution directory
         run: git stage ./dist
-      - name: Check if there is anything to commit
-        id: anything-to-commit
-        run: echo "::set-output name=diff::$( git diff --cached )"
-      - if: ${{ steps.anything-to-commit.outputs.diff != '' }}
+      - if: ${{ steps.check-for-changes.outputs.diff != '' }}
         name: Push the distribution file
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git commit -m "Update distribution file"
-          git push --force "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" "HEAD:$GITHUB_HEAD_REF"
-
+          git push --force "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" "HEAD:$GITHUB_REF"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Feel free to open a PR. GitHub Actions will automatically build & push the distribution file after each push.
 
+Don't worry when the build & check action doesn't run: it has to be triggered manually as it is not triggered when [workflow pushes](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token).
+
 ## Releasing
 
 To make a new release, simply create a new GitHub release (& tag), wait and update release notes after a while.


### PR DESCRIPTION
Existing workflow is changed to run on every push (except master), which works even in forks. Another workflow for checking the PR is added.

Closes #15.